### PR TITLE
Add initial project infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+dist6

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "eslintIntegration": true,
+  "bracketSpacing": false,
+  "singleQuote": true,
+  "printWidth": 80,
+  "trailingComma": "all"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+  "editor.rulers": [80],
+  "editor.tabCompletion": true,
+  "editor.tabSize": 2,
+  "editor.trimAutoWhitespace": true,
+  "editor.formatOnSave": true,
+
+  "files.exclude": {
+    "**/.DS_Store": true,
+    "**/.git": true,
+    "**/.hg": true,
+    "**/.svn": true,
+    "**/CVS": true,
+    "dist": true,
+    "dist6": true
+  },
+  "files.insertFinalNewline": true,
+  "files.trimTrailingWhitespace": true,
+
+  "tslint.ignoreDefinitionFiles": true,
+  "typescript.tsdk": "./node_modules/typescript/lib"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,46 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "taskName": "Watch and compile TypeScript",
+      "command": "tsc",
+      "args": ["--watch"],
+      "type": "process",
+      "isBackground": true,
+      "problemMatcher": "$tsc-watch",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "presentation": {
+        "echo": true,
+        "reveal": "never",
+        "focus": false,
+        "panel": "dedicated"
+      }
+    },
+    {
+      "taskName": "Test and lint",
+      "command": "npm",
+      "args": [
+        "--silent",
+        "run",
+        "vscode-test"
+      ],
+      "type": "process",
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "dedicated"
+      },
+      "problemMatcher": "$tslint5"
+    }
+  ]
+}

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,21 @@
+# Developer's Guide
+
+We use Visual Studio Code for developing LoopBack and recommend the same to our contributors.
+
+While this package supports both Node.js 6.x and 8.x versions, you will need Node.js 8.x (or newer) for the best development experience in VS Code.
+
+## VSCode setup
+
+Install the following extensions:
+
+ - [tslint](https://marketplace.visualstudio.com/items?itemName=eg2.tslint)
+ - [prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
+
+## Development workflow
+
+1. Start the build task (Cmd+Shift+B), it will run TypeScript compiler in backround, watching and recompiling files as you change them. Compilation errors will be shown in the VSCode's "PROBLEMS" window.
+
+
+2. Execute "Test and lint" task (Cmd+Shift+T) to re-run the test suite and lint the code for both programming and style errors. Linting errors will be shown in VSCode's "PROBLEMS" window. Failed tests are printed to terminal output only.
+
+3. Run "npm test" explicitly before committing your changes. This will execute the same sequence as our CI server does.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
 # loopback-next-extension-starter
-A starter project to create extensions for loopback-next
 
-Starting point to create a variety of extensions for loopback-next.
+A starter project to create extensions for loopback-next.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,6 @@
+// Copyright IBM Corp. 2017. All Rights Reserved.
+// Node module: @loopback/core
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+export * from './dist/lib';

--- a/index.js
+++ b/index.js
@@ -1,0 +1,9 @@
+// Copyright IBM Corp. 2017. All Rights Reserved.
+// Node module: @loopback/core
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+const nodeMajorVersion = +process.versions.node.split('.')[0];
+module.exports = nodeMajorVersion >= 7 ?
+  require('./dist/lib') :
+  require('./dist6/lib');

--- a/package.json
+++ b/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "loopback-next-extension-starter",
+  "version": "1.0.0",
+  "description": "A starter project for LoopBack Next Extensions",
+  "main": "index.js",
+  "scripts": {
+    "build": "npm run build:lib && npm run build:lib6",
+    "build:lib": "tsc --target es2017 --outDir dist",
+    "build:lib6": "tsc --target es2015 --outDir dist6",
+    "lint": "tslint -c tslint.full.json --project tsconfig.json --type-check",
+    "lint:fix": "npm run lint -- --fix",
+    "prepublish": "npm run build",
+    "pretest": "npm run build",
+    "test": "mocha",
+    "posttest": "npm run lint",
+    "vscode-test": "mocha && npm run lint"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/strongloop/loopback-next-extension-starter.git"
+  },
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/strongloop/loopback-next-extension-starter/issues"
+  },
+  "homepage": "https://github.com/strongloop/loopback-next-extension-starter#readme",
+  "files": [
+    "README.md",
+    "index.js",
+    "index.d.ts",
+    "dist",
+    "dist6"
+  ],
+  "dependencies": {
+    "@loopback/core": "^4.0.0-alpha.14",
+    "@loopback/repository": "^4.0.0-alpha.8"
+  },
+  "devDependencies": {
+    "@loopback/testlab": "^4.0.0-alpha.7",
+    "@types/mocha": "^2.2.43",
+    "mocha": "^3.5.3",
+    "tslint": "^5.7.0",
+    "typescript": "^2.5.2"
+  }
+}

--- a/src/controllers/README.md
+++ b/src/controllers/README.md
@@ -1,0 +1,3 @@
+# Controllers
+
+This directory contains source files for the controllers exported by this extension.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,4 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: loopback-next-extension-starter
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT

--- a/src/providers/README.md
+++ b/src/providers/README.md
@@ -1,0 +1,4 @@
+# Providers
+
+This directory contains providers contributing additional bindings, for example
+custom sequence actions.

--- a/src/repositories/README.md
+++ b/src/repositories/README.md
@@ -1,0 +1,3 @@
+# Repositories
+
+This directory contains code for repositories provided by this extension.

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,3 @@
+--recursive
+--reporter dot
+dist/test

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -1,0 +1,12 @@
+// Copyright IBM Corp. 2017. All Rights Reserved.
+// Node module: loopback-next-extension-starter
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+
+describe('Smoke test to verify project setup - remove me later', () => {
+  it('works', () => {
+    expect(true).to.equal(true);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noUnusedLocals": true,
+
+    "lib": ["es2017", "dom"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "es2017",
+    "outDir": "dist",
+    "sourceMap": true,
+    "declaration": true
+  },
+  "include": [
+    "src",
+    "test"
+  ]
+}

--- a/tslint.full.json
+++ b/tslint.full.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json.schemastore.org/tslint",
+    "extends": [
+      "./tslint.json"
+    ],
+    // This configuration files enabled rules which require type checking
+    // and therefore cannot be run by Visual Studio Code TSLint extension
+    // See https://github.com/Microsoft/vscode-tslint/issues/70
+    "rules": {
+      // These rules find errors related to TypeScript features.
+  
+  
+      // These rules catch common errors in JS programming or otherwise
+      // confusing constructs that are prone to producing bugs.
+  
+      "await-promise": true,
+      "no-floating-promises": true,
+      "no-void-expression": [true, "ignore-arrow-function-shorthand"]
+    }
+  }
+  

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,72 @@
+{
+  // See https://palantir.github.io/tslint/rules/
+  "rules": {
+    // These rules find errors related to TypeScript features.
+    "adjacent-overload-signatures": true,
+    "prefer-for-of": true,
+    "unified-signatures": true,
+    "no-any": true,
+
+    // These rules catch common errors in JS programming or otherwise
+    // confusing constructs that are prone to producing bugs.
+
+    "label-position": true,
+    "no-arg": true,
+    "no-construct": true,
+    "no-duplicate-variable": true,
+
+    "no-invalid-this": true,
+    "no-misused-new": true,
+    "no-shadowed-variable": true,
+    "no-string-throw": true,
+    "no-unused-expression": true,
+    "no-var-keyword": true,
+    "triple-equals": [
+      true,
+      "allow-null-check",
+      "allow-undefined-check"
+    ],
+    "typeof-compare": true,
+
+    // These rules make code maintenance easier
+    "eofline": true,
+    "indent": [true, "spaces"],
+    "no-default-export": true,
+    "no-trailing-whitespace": true,
+    "prefer-const": true,
+    "trailing-comma": [true, {
+      "multiline": "always",
+      "singleline": "never"
+    }],
+
+    // These rules enforce consistent style across your codebase:
+    "arrow-return-shorthand": [true],
+    "class-name": true,
+    "comment-format": [true, "check-space"],
+    "file-header": [true, "Copyright IBM"],
+    "max-line-length": [true, 80],
+    "no-consecutive-blank-lines": [true, 2],
+    "no-unnecessary-callback-wrapper": true,
+    "one-variable-per-declaration": [true, "ignore-for-loop"],
+    "prefer-method-signature": true,
+    "quotemark": [true, "single", "avoid-escape"],
+    "semicolon": [true, "always"],
+    "space-before-function-paren": [true, {
+      "anonymous": "never",
+      "named": "never",
+      "asyncArrow": "always",
+      "method": "never",
+      "constructor": "never"
+    }],
+    "variable-name": [true, "allow-leading-underscore", "ban-keywords", "check-format"],
+    "whitespace": [
+      true,
+      "check-branch",
+      "check-decl",
+      "check-separator",
+      "check-type",
+      "check-typecast",
+      "check-preblock"
+    ]
+  }
+}


### PR DESCRIPTION
This pull request takes parts of #1 and makes the following changes:

- remove tsconfig.common.json, it's not needed in a single-package repo
- remove "exclude" from tsconfig, not needed
- add typescript as a dependency, configured build - slightly differently than in loopback-next, I'd like to try out a better setup
- add linting step
- add top-level index.js, src/index.ts
- add simple smoke test, configure mocha
- add VSCode project config
  - tsc-watch task + problem matcher
  - test + lint task
- explicitly list files to include in the npm package
- add `DEVELOPING.md` describing the dev setup
  - Node.js 8.x or newer only
  - VSCode + extensions: Prettier, tslint
  - command+shift+b to start typescript watch/build in background
  - command+shift+t to run the tests and lint the code

@virkt25 @kjdelisle PTAL